### PR TITLE
Better filtering of non-numerical values

### DIFF
--- a/src/is-number.js
+++ b/src/is-number.js
@@ -1,0 +1,3 @@
+export function isNumber(value) {
+  return value !== null && value !== '' && isFinite(value);
+}

--- a/src/method-equal.js
+++ b/src/method-equal.js
@@ -1,8 +1,9 @@
 import * as d3array from "d3-array";
+import { isNumber } from "./is-number";
 const d3 = Object.assign({}, d3array);
 
 export function equal(data, nb){
-  data = data.filter((d) => isFinite(d)).map((x) => +x);
+  data = data.filter((d) => isNumber(d)).map((x) => +x);
   if (nb > data.length) return null;
   const breaks = [d3.min(data), d3.max(data)];
   const r = (breaks[1] - breaks[0]) / nb; // raison

--- a/src/method-jenks.js
+++ b/src/method-jenks.js
@@ -1,3 +1,5 @@
+import { isNumber } from "./is-number";
+
 function breaks(data, lower_class_limits, n_classes) {
   const kclass = [];
   let m = data.length,
@@ -75,7 +77,7 @@ function getMatrices(data, n_classes) {
 }
 
 export function jenks(data, nb){
-  data = data.filter((d) => isFinite(d))
+  data = data.filter((d) => isNumber(d))
     .map((x) => +x)
     .sort(function (a, b) {
       return a - b;

--- a/src/method-msd.js
+++ b/src/method-msd.js
@@ -1,8 +1,9 @@
 import * as d3array from "d3-array";
+import { isNumber } from "./is-number";
 const d3 = Object.assign({}, d3array);
 
 export function msd(data, k = 1, middle = false) {
-  data = data.filter((d) => isFinite(d)).map((x) => +x);
+  data = data.filter((d) => isNumber(d)).map((x) => +x);
 
   const min = d3.min(data);
   const max = d3.max(data);

--- a/src/method-q6.js
+++ b/src/method-q6.js
@@ -1,8 +1,9 @@
 import * as d3array from "d3-array";
+import { isNumber } from "./is-number";
 const d3 = Object.assign({}, d3array);
 
 export function q6(data){
-  data = data.filter((d) => isFinite(d)).map((x) => +x);
+  data = data.filter((d) => isNumber(d)).map((x) => +x);
   if (6 > data.length) return null;
   const breaks = [
     d3.quantile(data, 0),

--- a/src/method-quantile.js
+++ b/src/method-quantile.js
@@ -1,8 +1,9 @@
 import * as d3array from "d3-array";
+import { isNumber } from "./is-number";
 const d3 = Object.assign({}, d3array);
 
 export function quantile(data, nb) {
-  data = data.filter((d) => isFinite(d)).map((x) => +x);
+  data = data.filter((d) => isNumber(d)).map((x) => +x);
   if (nb > data.length) return null;
   const breaks = [];
   const q = 1 / nb;

--- a/src/shape.js
+++ b/src/shape.js
@@ -3,11 +3,12 @@ import * as d3selection from "d3-selection";
 import * as d3scale from "d3-scale";
 import * as d3shape from "d3-shape";
 import {equal} from "./method-equal.js";
+import { isNumber } from "./is-number";
 const d3 = Object.assign({}, d3array, d3selection, d3scale, d3shape);
 
 export function shape(data, precision = 25, marks = true, log = false) {
   data = data
-    .filter((d) => isFinite(d))
+    .filter((d) => isNumber(d))
     .map((x) => +x)
     .sort(d3.ascending);
 

--- a/src/view.js
+++ b/src/view.js
@@ -2,6 +2,7 @@ import * as d3array from "d3-array";
 import * as d3selection from "d3-selection";
 import * as d3scale from "d3-scale";
 import * as d3shape from "d3-shape";
+import { isNumber } from "./is-number";
 const d3 = Object.assign({}, d3array, d3selection, d3scale, d3shape);
 
 export function view(breaks, cols = null, data = null) {
@@ -27,7 +28,7 @@ export function view(breaks, cols = null, data = null) {
 
   if (data != null) {
     data = data
-      .filter((d) => isFinite(d))
+      .filter((d) => isNumber(d))
       .map((x) => +x)
       .sort(d3.ascending);
     svg


### PR DESCRIPTION
This PR follows #2 and #4.

I was a little mistaken about the use of `isFinite` which still returns `true` for `null` or `''` (empty string).
I think a better way to filter is `d !== null && d !== '' && isFinite(d)` (this is roughly what I use in Magrit).
That is what is done in this PR by introducing a `isNumber` helper function.


- Before #4:

```js
> [null, undefined, "", "abc", 0, "0", 1, 2, NaN, Infinity, {}].filter(d => d != '')
(9) [null, undefined, 'abc', '0', 1, 2, NaN, Infinity, {}]
```
Only empty string, but also actual `0`, were filtered out (but `null`, `NaN`, `Infinity`, `undefined`, non empty strings and objects were kept).


- After #4:

```js
> [null, undefined, "", "abc", 0, "0", 1, 2, NaN, Infinity, {}].filter(d => isFinite(d))
(6) [null, '', 0, '0', 1, 2]
```
Only elements that can be cast to Numbers were kept ( `null` and empty string were kept because they are converted to `0` when casted to Number by `isFinite`, so they are 'finite' for JS).


- After this PR:

```js
> [null, undefined, "", "abc", 0, "0", 1, 2, NaN, Infinity, {}].filter(d => isNumber(d))
(4) [0, '0', 1, 2]
```

Hopefully only elements than can really represent finite numbers are left in the array.
