### PR TITLE
Use min/max function that wont cause stack overflow

### DIFF
--- a/src/helpers/max.js
+++ b/src/helpers/max.js
@@ -3,9 +3,16 @@ import { isNumber } from "./is-number.js";
 /**
  * Find the maximum value of an array
  * @param {Number[]} x - An array of values
- * @returns {Number} - Maximuym value
+ * @returns {Number} - Maximum value
  */
 
 export function max(x) {
-  return Math.max(...x.filter((d) => isNumber(d)).map((a) => +a));
+  let maximum = -Infinity;
+  for (let i = 0, length = x.length; i < length; i++) {
+    if (isNumber(x[i]) && x[i] > maximum) {
+      maximum = x[i];
+    }
+  }
+
+  return maximum;
 }

--- a/src/helpers/min.js
+++ b/src/helpers/min.js
@@ -7,5 +7,12 @@ import { isNumber } from "./is-number.js";
  */
 
 export function min(x) {
-  return Math.min(...x.filter((d) => isNumber(d)).map((a) => +a));
+  let minimum = Infinity;
+  for (let i = 0, length = x.length; i < length; i++) {
+    if (isNumber(x[i]) && x[i] < minimum) {
+      minimum = x[i];
+    }
+  }
+
+  return minimum;
 }


### PR DESCRIPTION
Large arrays can cause stack overflow when using Math.min / Math.max (see https://github.com/simogeo/geostats/issues/33) and I think using a regular `for` loop can be marginally faster.

By the way, I kept the call to `isNumber` as in your original code, but it seems that `min` and `max` functions are always called on arrays that were previously filtered to remove non-numeric values, so maybe we can avoid calling `isNumber` on each array member (let me know if you want me to make this change before merging this PR).