### PR TITLE
Fix #20 and fix docstring for head-tail breaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Unreleased
+
+- Fix *head tail breaks* when `minmax` option is `true` (fixes #20).
+
+## 1.0.0 (2023-06-28)
+
+- Add *pretty breaks* and *arithmetic progression* classification methods.
+- Add object-oriented API.
+- Throw error instead of returning `null`:
+  - when the number of classes is greater than the number of values,
+  - when using a series with negative or zero values with *geometric progression* classification method,
+  - when using an unknown classification method name in `breaks` function.
+- Remove dependency on d3-array, d3-scale, d3-selection and d3-shape.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix *head tail breaks* when `minmax` option is `true` (fixes #20).
+- Fix *head tail breaks* when `minmax` option is `false` (fixes #20).
 
 ## 1.0.0 (2023-06-28)
 

--- a/src/method-headtail.js
+++ b/src/method-headtail.js
@@ -15,7 +15,6 @@ import { mean } from "./helpers/mean";
  * @param {number} [options.precision = 2] - Number of digits
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
- * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
  *
  */
 

--- a/src/method-headtail.js
+++ b/src/method-headtail.js
@@ -63,11 +63,5 @@ export function headtail(data, options = {}) {
     breaks = breaks.slice(1, -1);
   }
 
-  if (Number.isInteger(precision)) {
-    breaks = roundarray(breaks, precision);
-  }
-  if (!minmax) {
-    breaks = breaks.slice(1, -1);
-  }
   return breaks;
 }


### PR DESCRIPTION
This PR fixes #20 by removing duplicate code and it removes erronous information from the function docstring (as headtail does not fail if the number of classes requested is greater than the number of values).

I also propose to add a *changelog* to keep track of changes made (and record changes not yet released).
Don't hesitate to edit my PR if you prefer another form of changelog (and/or if you want to retroactively complete this changelog).