### PR TITLE
Improve validation of the `nb` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix *head tail breaks* when `minmax` option is `false` (fixes #20).
+- Improve validation of the `nb` parameter (fixes #25).
 
 ## 1.0.0 (2023-06-28)
 

--- a/src/classifier.js
+++ b/src/classifier.js
@@ -12,7 +12,7 @@ import { geometricProgression } from "./method-geometric-progression";
 import { headtail } from "./method-headtail";
 import { isNumber } from "./helpers/is-number";
 import { pretty } from "./method-pretty";
-import {arithmeticProgression} from './method-arithmetic-progression';
+import { arithmeticProgression } from './method-arithmetic-progression';
 
 class AbstractClassifier {
   constructor(values, precision) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -28,7 +28,15 @@ class UnknownMethodError extends Error {
   }
 }
 
+class InvalidNumberOfClassesError extends Error {
+  constructor(message) {
+    super(message || "Invalid number of classes");
+    this.name = 'InvalidNumberOfClassesError';
+  }
+}
+
 export {
+  InvalidNumberOfClassesError,
   ValuesInferiorOrEqualToZeroError,
   TooFewValuesError,
   UnknownMethodError,

--- a/src/helpers/is-number.js
+++ b/src/helpers/is-number.js
@@ -1,3 +1,16 @@
+/**
+ * Check if value is a number or can be correctly converted to a finite number.
+ * As such it returns false if value is null or undefined,
+ * if it's a string, even an empty string (casting empty string to number gives 0),
+ * if it's a boolean (casting them to number gives 0 or 1) or if it's NaN, Infinity or -Infinity.
+ * It returns true for numbers and strings containing numbers (even with leading or trailing spaces).
+ *
+ * @param {any} value - The value to test.
+ * @returns {boolean} - True if value is a number or can be converted to a finite number, false otherwise.
+ */
 export function isNumber(value) {
-  return value !== null && value !== '' && isFinite(value);
+  return value !== null
+    && value !== ''
+    && typeof value !== 'boolean'
+    && isFinite(value);
 }

--- a/src/helpers/parameter-validation.js
+++ b/src/helpers/parameter-validation.js
@@ -1,0 +1,30 @@
+import { InvalidNumberOfClassesError } from '../errors';
+import { isNumber } from './is-number';
+
+/**
+ * Validate the 'nb' parameter and return it if it is valid
+ * @param {any} nb
+ * @returns {number} - The 'nb' parameter, converted to a number
+ */
+function validateNbParameter(nb) {
+  // Test that the 'nb' parameter is a number or can be converted to a number
+  if (!isNumber(nb)) {
+    throw new InvalidNumberOfClassesError("The 'nb' parameter must be a number");
+  }
+  // Convert the 'nb' parameter to a number if it is a string
+  nb = +nb;
+  // Test that the 'nb' parameter is an integer
+  if (!Number.isInteger(nb)) {
+    throw new InvalidNumberOfClassesError("The 'nb' parameter must be an integer");
+  }
+  // Test that the 'nb' parameter is equal or superior to 2
+  if (nb < 2) {
+    throw new InvalidNumberOfClassesError("The 'nb' parameter must be superior or equal to 2");
+  }
+  // Return the 'nb' parameter
+  return nb;
+}
+
+export {
+  validateNbParameter,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export { geometricProgression } from "./method-geometric-progression";
 export { arithmeticProgression } from "./method-arithmetic-progression";
 export { pretty } from "./method-pretty";
 export {
+  InvalidNumberOfClassesError,
   ValuesInferiorOrEqualToZeroError,
   TooFewValuesError,
   UnknownMethodError,

--- a/src/method-arithmetic-progression.js
+++ b/src/method-arithmetic-progression.js
@@ -22,7 +22,7 @@ import { validateNbParameter } from './helpers/parameter-validation';
 
 export function arithmeticProgression(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
-  let nb = options.nb ? validateNbParameter(options.nb) : 5;
+  let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
   let precision = isNumber(options.precision) ? options.precision : 2;
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;

--- a/src/method-arithmetic-progression.js
+++ b/src/method-arithmetic-progression.js
@@ -3,6 +3,7 @@ import { min } from "./helpers/min";
 import { max } from "./helpers/max";
 import { roundarray } from "./helpers/rounding";
 import { TooFewValuesError } from "./errors";
+import { validateNbParameter } from './helpers/parameter-validation';
 
 /**
  * Arithmetic progression
@@ -16,12 +17,12 @@ import { TooFewValuesError } from "./errors";
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
- *
+ * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
  */
 
 export function arithmeticProgression(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
-  let nb = isNumber(options.nb) ? options.nb : 5;
+  let nb = options.nb ? validateNbParameter(options.nb) : 5;
   let precision = isNumber(options.precision) ? options.precision : 2;
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;

--- a/src/method-equal.js
+++ b/src/method-equal.js
@@ -2,6 +2,7 @@ import { isNumber } from "./helpers/is-number";
 import { roundarray } from "./helpers/rounding";
 import { min } from "./helpers/min";
 import { max } from "./helpers/max";
+import { validateNbParameter } from './helpers/parameter-validation';
 import { TooFewValuesError } from "./errors";
 
 /**
@@ -16,12 +17,13 @@ import { TooFewValuesError } from "./errors";
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
+ * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
  *
  */
 
 export function equal(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
-  let nb = isNumber(options.nb) ? options.nb : 5;
+  let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
   let precision = isNumber(options.precision) ? options.precision : 2;
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;

--- a/src/method-geometric-progression.js
+++ b/src/method-geometric-progression.js
@@ -3,6 +3,7 @@ import { min } from "./helpers/min";
 import { max } from "./helpers/max";
 import { roundarray } from "./helpers/rounding";
 import { TooFewValuesError, ValuesInferiorOrEqualToZeroError } from "./errors";
+import { validateNbParameter } from './helpers/parameter-validation';
 
 /**
  * Geometric progression
@@ -17,12 +18,12 @@ import { TooFewValuesError, ValuesInferiorOrEqualToZeroError } from "./errors";
  * @returns {number[]} - An array of breaks.
  * @throws {ValuesInferiorOrEqualToZeroError} - If input array contains negative or zero values.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
- *
+ * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
  */
 
 export function geometricProgression(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
-  let nb = isNumber(options.nb) ? options.nb : 5;
+  let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
   let precision = isNumber(options.precision) ? options.precision : 2;
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;

--- a/src/method-headtail.js
+++ b/src/method-headtail.js
@@ -3,6 +3,7 @@ import { roundarray } from "./helpers/rounding";
 import { min } from "./helpers/min";
 import { max } from "./helpers/max";
 import { mean } from "./helpers/mean";
+import { validateNbParameter } from './helpers/parameter-validation';
 
 /**
  * Head/tail algorithm v1.0 based on Jiang (2019).
@@ -15,12 +16,12 @@ import { mean } from "./helpers/mean";
  * @param {number} [options.precision = 2] - Number of digits
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
- *
+ * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
  */
 
 export function headtail(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
-  let nb = isNumber(options.nb) ? options.nb : 5;
+  let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
   let precision = isNumber(options.precision) ? options.precision : 2;
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;

--- a/src/method-jenks.js
+++ b/src/method-jenks.js
@@ -1,6 +1,7 @@
 import { isNumber } from "./helpers/is-number";
 import { roundarray } from "./helpers/rounding";
 import { TooFewValuesError } from './errors';
+import { validateNbParameter } from './helpers/parameter-validation';
 
 function breaks(data, lower_class_limits, n_classes) {
   const kclass = [];
@@ -101,7 +102,7 @@ function getMatrices(data, n_classes) {
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of (unique) values is less than the number of classes.
- *
+ * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
  */
 export function jenks(data, options = {}) {
   data = data
@@ -111,7 +112,7 @@ export function jenks(data, options = {}) {
       return a - b;
     });
 
-  let nb = isNumber(options.nb) ? options.nb : 5;
+  let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
   let precision = isNumber(options.precision) ? options.precision : 2;
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;

--- a/src/method-msd.js
+++ b/src/method-msd.js
@@ -17,7 +17,6 @@ import { deviation } from "./helpers/deviation";
  * @param {boolean} [options.middle = true] - To have the average as a class center
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
- * @throws {TooFewValuesError} - If the number of values is less than 6.
  *
  */
 

--- a/src/method-quantile.js
+++ b/src/method-quantile.js
@@ -2,6 +2,7 @@ import { isNumber } from "./helpers/is-number";
 import { roundarray } from "./helpers/rounding";
 import { quantil } from "./helpers/quantile";
 import { TooFewValuesError } from "./errors";
+import { validateNbParameter } from './helpers/parameter-validation';
 
 /**
  * Classification by quantiles
@@ -15,13 +16,12 @@ import { TooFewValuesError } from "./errors";
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
- *
- *
+ * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
  */
 
 export function quantile(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
-  let nb = isNumber(options.nb) ? options.nb : 5;
+  let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
   let precision = isNumber(options.precision) ? options.precision : 2;
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;

--- a/test/equalinterval.test.js
+++ b/test/equalinterval.test.js
@@ -4,13 +4,13 @@ const statsbreaks = require("../dist/index.min.js");
 
 test("equal", function (t) {
   t.test('should return correct breaks for the test data', function (t) {
-    const breaks = statsbreaks.breaks(X, { method: 'equal', nbClass: 5 });
+    const breaks = statsbreaks.breaks(X, { method: 'equal', nb: 5 });
     t.same(breaks, [0.13, 822.39, 1644.66, 2466.92, 3289.19, 4111.45]);
     t.end();
   });
 
   t.throws(function() {
-      const breaks = statsbreaks.breaks([1, 2, 3], { method: 'equal', nbClass: 5 });
+      const breaks = statsbreaks.breaks([1, 2, 3], { method: 'equal', nb: 5 });
     },
     new statsbreaks.TooFewValuesError('Too few values for the given number of breaks'),
     'should throw error if the number of classes is too high',

--- a/test/headtail.test.js
+++ b/test/headtail.test.js
@@ -4,7 +4,7 @@ const statsbreaks = require("../dist/index.min.js");
 
 test("headtail", function (t) {
   t.test('should return correct breaks for the test data', function (t) {
-    const breaks = statsbreaks.breaks(X, { method: 'headtail', nbClass: 3 });
+    const breaks = statsbreaks.breaks(X, { method: 'headtail', nb: 3 });
     t.same(breaks, [0.13, 125.93, 811.26, 4111.45]);
     t.end();
   });

--- a/test/jenks.test.js
+++ b/test/jenks.test.js
@@ -4,13 +4,13 @@ const statsbreaks = require("../dist/index.min.js");
 
 test("jenks", function (t) {
   t.test('should return correct breaks for the test data', function (t) {
-    const breaks = statsbreaks.breaks(X, { method: 'jenks', nbClass: 5 });
+    const breaks = statsbreaks.breaks(X, { method: 'jenks', nb: 5 });
     t.same(breaks, [0.13, 75.29, 192.05, 370.50, 722.85, 4111.45]);
     t.end();
   });
 
   t.throws(function() {
-      const breaks = statsbreaks.breaks([1, 2, 3], { method: 'jenks', nbClass: 5 });
+      const breaks = statsbreaks.breaks([1, 2, 3], { method: 'jenks', nb: 5 });
     },
     new statsbreaks.TooFewValuesError('Too few values for the given number of breaks'),
     'should throw error if the number of classes is too high',

--- a/test/minmax-parameter-behavior.test.js
+++ b/test/minmax-parameter-behavior.test.js
@@ -1,0 +1,31 @@
+const test = require("tap").test;
+const statsbreaks = require("../dist/index.min.js");
+const X = require('./test-data');
+
+const methods = [
+  'equal',
+  'quantile',
+  'arithmetic',
+  'geometric',
+  'jenks',
+  'headtail',
+  'pretty',
+  'msd',
+  'q6',
+];
+
+// Run the tests for each method
+methods.forEach(function(method) {
+  test(`The 'minmax' parameter, `, function (t) {
+    t.test('should always return an array with 2 fewer elements than if not used',
+      function (t) {
+        const b1 = statsbreaks.breaks(X, { method, minmax: false });
+        const b2 = statsbreaks.breaks(X, { method });
+
+        t.same(b2.length - 2, b1.length);
+
+        t.end();
+      });
+    t.end();
+  });
+});

--- a/test/nb-param-behavior.test.js
+++ b/test/nb-param-behavior.test.js
@@ -1,0 +1,112 @@
+const test = require("tap").test;
+const statsbreaks = require("../dist/index.min.js");
+const X = require('./test-data');
+
+const InvalidNumberOfClassesError = statsbreaks.InvalidNumberOfClassesError;
+
+// Methods that use the 'nb' parameter (so 'msd' and 'q6' are not included)
+const methodThatUseNbParameter = [
+  'equal',
+  'quantile',
+  'arithmetic',
+  'geometric',
+  'jenks',
+  'headtail',
+  'pretty',
+];
+
+// Run the tests for each method
+methodThatUseNbParameter.forEach(function(method) {
+  test(`The 'nb' parameter, `, function (t) {
+    // Test with positive integer, inferior to two
+    t.throws(function() {
+        const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: 1 });
+      },
+      new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be superior or equal to 2"),
+      `on method ${method}, should throw error if the number of classes inferior to 2`,
+    );
+
+    // Test with negative integer
+    t.throws(function() {
+        const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: -1 });
+      },
+      new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be superior or equal to 2"),
+      `on method ${method}, should throw error if the number of classes inferior to 2`,
+    );
+
+    // Test with a string that can't be converted to a positive integer
+    t.throws(function() {
+        const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: 'abc' });
+      },
+      new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be a number"),
+      `on method ${method}, should throw error if the number of classes is not a number`,
+    );
+
+    // Test with a floating-point number
+    t.throws(function() {
+        const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: 5.6 });
+      },
+      new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be an integer"),
+      `on method ${method}, should throw error if the number of classes is a number but not an integer`,
+    );
+
+    // Test with a boolean
+    t.throws(function() {
+        const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: true });
+      },
+      new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be a number"),
+      `on method ${method}, should throw error if the number of classes is not a number`,
+    );
+
+    // Test with an empty object
+    t.throws(function() {
+        const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: {} });
+      },
+      new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be a number"),
+      `on method ${method}, should throw error if the number of classes is not a number`,
+    );
+
+    // Test with a non-empty object
+    t.throws(function() {
+        const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: { abc: 12 } });
+      },
+      new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be a number"),
+      `on method ${method}, should throw error if the number of classes is not a number`,
+    );
+
+    // Test with a string that can be converted to a positive integer
+    t.test(`on method ${method}, should succeed if the number of classes is a string that can be converted to a positive integer`,
+      function (t) {
+        const breaks = statsbreaks.breaks(X, { method, nb: '3' });
+        t.same(breaks.length, 4);
+        t.end();
+      });
+
+    // Test with nb null
+    t.test(`on method ${method}, should return breaks with 5 classes if nb is null`, function (t) {
+      const breaks = statsbreaks.breaks(X, { method, nb: null });
+
+      // Headtail is allowed to not return the desired number of classes
+      if (method !== 'headtail') {
+        t.same(breaks.length, 6);
+      }
+
+      t.end();
+    });
+
+    // Test with nb undefined
+    t.test(`on method ${method}, should return breaks with 5 classes if nb is undefined`, function (t) {
+      const breaks = statsbreaks.breaks(X, { method, nb: undefined });
+
+      // Headtail is allowed to not return the desired number of classes
+      if (method !== 'headtail') {
+        t.same(breaks.length, 6);
+      }
+
+      t.end();
+    });
+
+    t.end();
+  });
+
+});

--- a/test/nb-param-behavior.test.js
+++ b/test/nb-param-behavior.test.js
@@ -31,7 +31,15 @@ methodThatUseNbParameter.forEach(function(method) {
         const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: -1 });
       },
       new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be superior or equal to 2"),
-      `on method ${method}, should throw error if the number of classes inferior to 2`,
+      `on method ${method}, should throw error if the number of classes is negative`,
+    );
+
+    // Test with zero
+    t.throws(function() {
+        const breaks = statsbreaks.breaks([1, 2, 3, 4, 5, 6, 7, 8], { method, nb: 0 });
+      },
+      new statsbreaks.InvalidNumberOfClassesError("The 'nb' parameter must be superior or equal to 2"),
+      `on method ${method}, should throw error if the number of classes is equal to zero`,
     );
 
     // Test with a string that can't be converted to a positive integer

--- a/test/quantile.test.js
+++ b/test/quantile.test.js
@@ -4,13 +4,13 @@ const statsbreaks = require("../dist/index.min.js");
 
 test("quantile", function (t) {
   t.test('should return correct breaks for the test data', function (t) {
-    const breaks = statsbreaks.breaks(X, { method: 'quantile', nbClass: 5 });
+    const breaks = statsbreaks.breaks(X, { method: 'quantile', nb: 5 });
     t.same(breaks, [0.13, 1.46, 5.80, 13.28, 54.62, 4111.45]);
     t.end();
   });
 
   t.throws(function() {
-    const breaks = statsbreaks.breaks([1, 2, 3], { method: 'quantile', nbClass: 5 });
+    const breaks = statsbreaks.breaks([1, 2, 3], { method: 'quantile', nb: 5 });
   },
     new statsbreaks.TooFewValuesError('Too few values for the given number of breaks'),
     'should throw error if the number of classes is too high',


### PR DESCRIPTION
I've chosen to implement the following logic:
- if 'nb' parameter is null or undefined (this is tested by using '!= null' in the code, which exclude both null and undefined), it uses the default value of 5 as before
- if 'nb' is not a number nor a string that can be converted to a number : throws an error with an appropriate message
- if 'nb' is a number but not an integer : throws an error with an appropriate message
- if 'nb' is inferior to 2 : throws an error with an appropriate message

I've implemented what I hope is a comprehensive test suite for this parameter.
I also took the opportunity to test the 'minmax' parameter against the bug that was reported by @TomBor in #20.

I dont think it really makes sense to ask for less than 2 bins (especially since a parameter is proposed to remove the min and max from the returned breaks) but @neocarto if you prefer i'm also happy with changing it to only throw error if 'nb' is inferior to 1 and using a shortcut to return `[min, max]` without executing the rest of the method ?

@TomBor, do you think it fixes #25 ? Don't hesitate if I missed something.