### PR TITLE
add splitByClass to classifier methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix *head tail breaks* when `minmax` option is `false` (fixes #20).
 - Improve validation of the `nb` parameter (fixes #25).
+- Add *splitByClass* to classifier methods (fixed [#24](https://github.com/riatelab/statsbreaks/issues/24))
 
 ## 1.0.0 (2023-06-28)
 

--- a/src/classifier.js
+++ b/src/classifier.js
@@ -32,6 +32,7 @@ class AbstractClassifier {
     this._median = null;
     this._stddev = null;
     this._counts = null;
+    this._splitValues = null;
   }
 
   /**
@@ -174,6 +175,35 @@ class AbstractClassifier {
       this._counts = counts;
     }
     return this._counts;
+  }
+
+  /**
+   * Split the series by class.
+   *
+   * @returns {number[][]}
+   */
+  splitByClass() {
+    if (this._breaks === null) {
+      throw new Error(
+        'Breaks are not set, please call the "classify" method first'
+      );
+    }
+    if (this._splitValues === null) {
+      const splitValues = [];
+      const sortedValues = this._values.slice().sort((a, b) => a - b);
+      this._breaks
+        .slice(1,-1)
+        .forEach((b, i) => {
+        // First cluster
+        if (i === 0) splitValues.push(sortedValues.filter((d) => d <= b));
+        // Intermediate clusters
+        if (i !== 0) splitValues.push(sortedValues.filter((d) => d > this._breaks[i - 1] && d <= b));
+        // Last cluster
+        if (i === this._breaks.length - 1) splitValues.push(sortedValues.filter((d) => d > b));
+      });
+      this._splitValues = splitValues;
+    }
+    return this._splitValues;
   }
 
   /**


### PR DESCRIPTION
As discuss in [#24](https://github.com/riatelab/statsbreaks/issues/24), I propose a new method to classifier to split the series by class.

Classifier don't use minmax option, so I assume that breaks always have min and max. I hope it's fine.