### PR TITLE
Don't round break values if `precision` is set to `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Don't round values if `precision` option is explicitly set to `null` (partially fixes [#28](https://github.com/riatelab/statsbreaks/issues/28)).
+
 ## 1.0.2 (2023-07-12)
 
 - Add *splitByClass* to classifier methods (fixed [#24](https://github.com/riatelab/statsbreaks/issues/24))

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The **`breaks()`** function allows to compute breaks according to several discre
 Parameters
 
 - <b>`method`</b>: method of discretization. "quantile", "q6", "equal", "msd", "jenks", "geometric", "headtail" or "pretty" (default: "quantile")
-- <b>`nb`</b>: number of classes (default: "5")
-- <b>`precision`</b>: rounding of values. 2 transform 35667.877876 to 35667.87 -2 transform 35667.877876 to 35600. (default: 2)
+- <b>`nb`</b>: number of classes (default: 5)
+- <b>`precision`</b>: rounding of values. 2 transform 35667.877876 to 35667.87 -2 transform 35667.877876 to 35600. Set it to `null` to indicate breaks shouldn't be rounded (default: 2)
 - <b>`minmax`</b>: a boolean to keep or remove min and max values (default: true)
 - <b>`middle`</b>: a boolean to have the average as a class center. Available with "msd" method only (default: false)
 - <b>`k`</b>: Number of standard deviations taken into account. Available with "msd" method only (default: 1)
@@ -151,7 +151,7 @@ series.classify(7)
 series.countByClass()
 ~~~
 
-**`splitByClass`** creturns values for each class
+**`splitByClass`** returns values for each class
 
 ~~~js
 series.splitByClass()

--- a/src/classifier.js
+++ b/src/classifier.js
@@ -10,9 +10,9 @@ import { q6 } from "./method-q6";
 import { msd } from "./method-msd";
 import { geometricProgression } from "./method-geometric-progression";
 import { headtail } from "./method-headtail";
-import { isNumber } from "./helpers/is-number";
 import { pretty } from "./method-pretty";
 import { arithmeticProgression } from './method-arithmetic-progression';
+import {validatePrecisionParameter} from './helpers/parameter-validation';
 
 class AbstractClassifier {
   constructor(values, precision) {
@@ -22,7 +22,7 @@ class AbstractClassifier {
       );
     }
     this._values = values;
-    this.precision = precision == null || !isNumber(precision) ? 2 : precision;
+    this.precision = validatePrecisionParameter(precision);
     this.type = null;
     this.nClasses = null;
     this._breaks = null;
@@ -246,6 +246,7 @@ class JenksClassifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);
@@ -278,6 +279,7 @@ class QuantileClassifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);
@@ -310,6 +312,7 @@ class EqualClassifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);
@@ -342,6 +345,7 @@ class GeometricProgressionClassifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);
@@ -375,6 +379,7 @@ class Q6Classifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);
@@ -404,6 +409,7 @@ class CustomBreaksClassifier extends AbstractClassifier {
    * @param {number[]} values
    * @param {number[]} breaks - The break values to use.
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision, breaks) {
     super(values, precision);
@@ -435,6 +441,7 @@ class MsdClassifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);
@@ -467,6 +474,7 @@ class HeadTailClassifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);
@@ -498,6 +506,7 @@ class PrettyBreaksClassifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);
@@ -530,6 +539,7 @@ class ArithmeticProgressionClassifier extends AbstractClassifier {
    *
    * @param {number[]} values
    * @param precision
+   * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
    */
   constructor(values, precision) {
     super(values, precision);

--- a/src/errors.js
+++ b/src/errors.js
@@ -35,8 +35,16 @@ class InvalidNumberOfClassesError extends Error {
   }
 }
 
+class InvalidPrecisionError extends Error {
+  constructor(message) {
+    super(message || "Invalid precision");
+    this.name = 'InvalidPrecisionError';
+  }
+}
+
 export {
   InvalidNumberOfClassesError,
+  InvalidPrecisionError,
   ValuesInferiorOrEqualToZeroError,
   TooFewValuesError,
   UnknownMethodError,

--- a/src/helpers/parameter-validation.js
+++ b/src/helpers/parameter-validation.js
@@ -1,10 +1,12 @@
-import { InvalidNumberOfClassesError } from '../errors';
+import { InvalidNumberOfClassesError, InvalidPrecisionError } from '../errors';
 import { isNumber } from './is-number';
 
 /**
  * Validate the 'nb' parameter and return it if it is valid
  * @param {any} nb
  * @returns {number} - The 'nb' parameter, converted to a number
+ * @throws {InvalidNumberOfClassesError} - If the 'nb' parameter is not valid
+ *
  */
 function validateNbParameter(nb) {
   // Test that the 'nb' parameter is a number or can be converted to a number
@@ -25,6 +27,40 @@ function validateNbParameter(nb) {
   return nb;
 }
 
+/**
+ * Validate the 'precision' parameter and return it if it is valid
+ * @param {any} precision - The 'precision' parameter as passed by the user
+ * @returns {number | null} - The 'precision' parameter as a number, or null if the user explicitly set it to null
+ * @throws {InvalidPrecisionError} - If the 'precision' parameter is not valid
+ */
+function validatePrecisionParameter(precision) {
+  // If precision is explicitly set to null, return null, because be don't want to round the break values
+  if (precision === null) {
+    return null;
+  }
+  // If precision is undefined, return the default value that is currently 2
+  // (but this could change in the future to compute the default value from the values)
+  if (precision === undefined) {
+    return 2;
+  }
+  // Otherwise, test that the 'precision' parameter is a number or can be converted to a number
+  if (!isNumber(precision)) {
+    throw new InvalidPrecisionError("The 'precision' parameter must be a number");
+  }
+  // Convert the 'nb' parameter to a number if it is a string
+  precision = +precision;
+  // Test that the 'nb' parameter is an integer
+  if (!Number.isInteger(precision)) {
+    throw new InvalidPrecisionError("The 'precision' parameter must be an integer");
+  }
+  if (precision < 0) {
+    throw new InvalidPrecisionError("The 'precision' parameter must be superior or equal to 0");
+  }
+
+  return precision;
+}
+
 export {
   validateNbParameter,
-}
+  validatePrecisionParameter,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export { arithmeticProgression } from "./method-arithmetic-progression";
 export { pretty } from "./method-pretty";
 export {
   InvalidNumberOfClassesError,
+  InvalidPrecisionError,
   ValuesInferiorOrEqualToZeroError,
   TooFewValuesError,
   UnknownMethodError,

--- a/src/method-arithmetic-progression.js
+++ b/src/method-arithmetic-progression.js
@@ -3,7 +3,7 @@ import { min } from "./helpers/min";
 import { max } from "./helpers/max";
 import { roundarray } from "./helpers/rounding";
 import { TooFewValuesError } from "./errors";
-import { validateNbParameter } from './helpers/parameter-validation';
+import {validateNbParameter, validatePrecisionParameter} from './helpers/parameter-validation';
 
 /**
  * Arithmetic progression
@@ -18,12 +18,13 @@ import { validateNbParameter } from './helpers/parameter-validation';
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
  * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  */
 
 export function arithmeticProgression(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
   let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
-  let precision = isNumber(options.precision) ? options.precision : 2;
+  let precision = validatePrecisionParameter(options.precision);
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
 
@@ -50,7 +51,7 @@ export function arithmeticProgression(data, options = {}) {
     }
   }
 
-  if (Number.isInteger(precision)) {
+  if (precision !== null) {
     breaks = roundarray(breaks, precision);
   }
   if (!minmax) {

--- a/src/method-equal.js
+++ b/src/method-equal.js
@@ -2,7 +2,7 @@ import { isNumber } from "./helpers/is-number";
 import { roundarray } from "./helpers/rounding";
 import { min } from "./helpers/min";
 import { max } from "./helpers/max";
-import { validateNbParameter } from './helpers/parameter-validation';
+import {validateNbParameter, validatePrecisionParameter} from './helpers/parameter-validation';
 import { TooFewValuesError } from "./errors";
 
 /**
@@ -18,13 +18,14 @@ import { TooFewValuesError } from "./errors";
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
  * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  *
  */
 
 export function equal(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
   let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
-  let precision = isNumber(options.precision) ? options.precision : 2;
+  let precision = validatePrecisionParameter(options.precision);
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
   if (nb > data.length) throw new TooFewValuesError();
@@ -37,7 +38,8 @@ export function equal(data, options = {}) {
   }
 
   breaks = breaks.sort((a, b) => a - b);
-  if (Number.isInteger(precision)) {
+
+  if (precision !== null) {
     breaks = roundarray(breaks, precision);
   }
   if (!minmax) {

--- a/src/method-geometric-progression.js
+++ b/src/method-geometric-progression.js
@@ -3,7 +3,7 @@ import { min } from "./helpers/min";
 import { max } from "./helpers/max";
 import { roundarray } from "./helpers/rounding";
 import { TooFewValuesError, ValuesInferiorOrEqualToZeroError } from "./errors";
-import { validateNbParameter } from './helpers/parameter-validation';
+import {validateNbParameter, validatePrecisionParameter} from './helpers/parameter-validation';
 
 /**
  * Geometric progression
@@ -19,12 +19,13 @@ import { validateNbParameter } from './helpers/parameter-validation';
  * @throws {ValuesInferiorOrEqualToZeroError} - If input array contains negative or zero values.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
  * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  */
 
 export function geometricProgression(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
   let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
-  let precision = isNumber(options.precision) ? options.precision : 2;
+  let precision = validatePrecisionParameter(options.precision);
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
 
@@ -54,7 +55,8 @@ export function geometricProgression(data, options = {}) {
 
   // Output
   breaks = breaks.sort((a, b) => a - b);
-  if (Number.isInteger(precision)) {
+
+  if (precision !== null) {
     breaks = roundarray(breaks, precision);
   }
   if (!minmax) {

--- a/src/method-headtail.js
+++ b/src/method-headtail.js
@@ -3,7 +3,7 @@ import { roundarray } from "./helpers/rounding";
 import { min } from "./helpers/min";
 import { max } from "./helpers/max";
 import { mean } from "./helpers/mean";
-import { validateNbParameter } from './helpers/parameter-validation';
+import {validateNbParameter, validatePrecisionParameter} from './helpers/parameter-validation';
 
 /**
  * Head/tail algorithm v1.0 based on Jiang (2019).
@@ -17,12 +17,13 @@ import { validateNbParameter } from './helpers/parameter-validation';
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
  * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  */
 
 export function headtail(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
   let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
-  let precision = isNumber(options.precision) ? options.precision : 2;
+  let precision = validatePrecisionParameter(options.precision);
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
 
@@ -56,7 +57,7 @@ export function headtail(data, options = {}) {
   breaks.push(max(data));
 
   // Output
-  if (Number.isInteger(precision)) {
+  if (precision !== null) {
     breaks = roundarray(breaks, precision);
   }
   if (!minmax) {

--- a/src/method-jenks.js
+++ b/src/method-jenks.js
@@ -1,7 +1,7 @@
 import { isNumber } from "./helpers/is-number";
 import { roundarray } from "./helpers/rounding";
 import { TooFewValuesError } from './errors';
-import { validateNbParameter } from './helpers/parameter-validation';
+import {validateNbParameter, validatePrecisionParameter} from './helpers/parameter-validation';
 
 function breaks(data, lower_class_limits, n_classes) {
   const kclass = [];
@@ -103,6 +103,7 @@ function getMatrices(data, n_classes) {
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of (unique) values is less than the number of classes.
  * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  */
 export function jenks(data, options = {}) {
   data = data
@@ -113,7 +114,7 @@ export function jenks(data, options = {}) {
     });
 
   let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
-  let precision = isNumber(options.precision) ? options.precision : 2;
+  let precision = validatePrecisionParameter(options.precision);
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
 
@@ -124,7 +125,7 @@ export function jenks(data, options = {}) {
   let lower_class_limits = matrices.lower_class_limits;
   let result = breaks(data, lower_class_limits, nb);
 
-  if (Number.isInteger(precision)) {
+  if (precision !== null) {
     result = roundarray(result, precision);
   }
   if (!minmax) {

--- a/src/method-msd.js
+++ b/src/method-msd.js
@@ -4,6 +4,7 @@ import { min } from "./helpers/min";
 import { max } from "./helpers/max";
 import { mean } from "./helpers/mean";
 import { deviation } from "./helpers/deviation";
+import {validatePrecisionParameter} from './helpers/parameter-validation';
 
 /**
  * Classification based on mean and standard deviation
@@ -17,6 +18,7 @@ import { deviation } from "./helpers/deviation";
  * @param {boolean} [options.middle = true] - To have the average as a class center
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  *
  */
 
@@ -25,7 +27,7 @@ export function msd(data, options = {}) {
   let k = isNumber(options.k) ? options.k : 1;
   let middle =
     options.middle === false || options.middle == undefined ? false : true;
-  let precision = isNumber(options.precision) ? options.precision : 2;
+  let precision = validatePrecisionParameter(options.precision);
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
 
@@ -62,7 +64,7 @@ export function msd(data, options = {}) {
   }
 
   breaks = breaks.sort((a, b) => a - b);
-  if (Number.isInteger(precision)) {
+  if (precision !== null) {
     breaks = roundarray(breaks, precision);
   }
   if (!minmax) {

--- a/src/method-pretty.js
+++ b/src/method-pretty.js
@@ -4,7 +4,7 @@ import { min } from './helpers/min';
 import { max } from './helpers/max';
 import { arange } from './helpers/arange';
 import { TooFewValuesError } from './errors';
-import { validateNbParameter } from './helpers/parameter-validation';
+import {validateNbParameter, validatePrecisionParameter} from './helpers/parameter-validation';
 
 function prettyNumber(x, rounded = true) {
   let exp = Math.floor(Math.log10(x));
@@ -47,11 +47,12 @@ function prettyNumber(x, rounded = true) {
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
  * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  *
  */
 export function pretty(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
-  const precision = isNumber(options.precision) ? options.precision : 2;
+  const precision = validatePrecisionParameter(options.precision);
   const minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
   const nb = options.nb != null ? validateNbParameter(options.nb) : 5;
@@ -68,7 +69,7 @@ export function pretty(data, options = {}) {
 
   let breaks = arange(minY, maxY + 0.5 * d, d);
 
-  if (Number.isInteger(precision)) {
+  if (precision !== null) {
     breaks = roundarray(breaks, precision);
   }
   if (!minmax) {

--- a/src/method-q6.js
+++ b/src/method-q6.js
@@ -2,6 +2,7 @@ import { isNumber } from "./helpers/is-number";
 import { roundarray } from "./helpers/rounding";
 import { quantil } from "./helpers/quantile";
 import { TooFewValuesError } from './errors';
+import {validatePrecisionParameter} from './helpers/parameter-validation';
 
 /**
  * Q6 method
@@ -14,12 +15,13 @@ import { TooFewValuesError } from './errors';
  * @param {boolean} [options.minmax = true] - To keep or delete min and max
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  *
  */
 
 export function q6(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
-  let precision = isNumber(options.precision) ? options.precision : 2;
+  let precision = validatePrecisionParameter(options.precision);
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
   if (6 > data.length) throw new TooFewValuesError();
@@ -33,7 +35,7 @@ export function q6(data, options = {}) {
     quantil(data, 1),
   ];
 
-  if (Number.isInteger(precision)) {
+  if (precision !== null) {
     breaks = roundarray(breaks, precision);
   }
   if (!minmax) {

--- a/src/method-quantile.js
+++ b/src/method-quantile.js
@@ -2,7 +2,7 @@ import { isNumber } from "./helpers/is-number";
 import { roundarray } from "./helpers/rounding";
 import { quantil } from "./helpers/quantile";
 import { TooFewValuesError } from "./errors";
-import { validateNbParameter } from './helpers/parameter-validation';
+import {validateNbParameter, validatePrecisionParameter} from './helpers/parameter-validation';
 
 /**
  * Classification by quantiles
@@ -17,12 +17,13 @@ import { validateNbParameter } from './helpers/parameter-validation';
  * @returns {number[]} - An array of breaks.
  * @throws {TooFewValuesError} - If the number of values is less than the number of classes.
  * @throws {InvalidNumberOfClassesError} - If the number of classes is not valid (not an integer or less than 2).
+ * @throws {InvalidPrecisionError} - If the precision is not valid (not null, not an integer or less than 0).
  */
 
 export function quantile(data, options = {}) {
   data = data.filter((d) => isNumber(d)).map((x) => +x);
   let nb = options.nb != null ? validateNbParameter(options.nb) : 5;
-  let precision = isNumber(options.precision) ? options.precision : 2;
+  let precision = validatePrecisionParameter(options.precision);
   let minmax =
     options.minmax === true || options.minmax == undefined ? true : false;
 
@@ -34,7 +35,7 @@ export function quantile(data, options = {}) {
   }
 
   breaks = breaks.sort((a, b) => a - b);
-  if (Number.isInteger(precision)) {
+  if (precision !== null) {
     breaks = roundarray(breaks, precision);
   }
   if (!minmax) {

--- a/test/precision-param-behavior.test.js
+++ b/test/precision-param-behavior.test.js
@@ -1,0 +1,139 @@
+const test = require("tap").test;
+const statsbreaks = require("../dist/index.min.js");
+const X = require('./test-data');
+
+const InvalidPrecisionError = statsbreaks.InvalidPrecisionError;
+
+const allBreaksMethods = [
+  'arithmetic',
+  'equal',
+  'geometric',
+  'headtail',
+  'jenks',
+  'msd',
+  'pretty',
+  'q6',
+  'quantile',
+];
+
+// Run the tests for each method
+allBreaksMethods.forEach(function(method) {
+  test(`The 'precision' parameter, `, function (t) {
+    // Test with a negative integer
+    t.throws(function() {
+        const breaks = statsbreaks.breaks(X, { method, nb: 5, precision: -1 });
+      },
+      new InvalidPrecisionError("The 'precision' parameter must be superior or equal to 0"),
+      `should be superior or equal to 0 (on method ${method})`,
+    );
+
+    // Test with a floating-point number
+    t.throws(function() {
+        const breaks = statsbreaks.breaks(X, { method, nb: 5, precision: 2.7 });
+      },
+      new InvalidPrecisionError("The 'precision' parameter must be an integer"),
+      `should be an integer (on method ${method})`,
+    );
+
+    // Test with a string that can't be converted to a positive integer
+    t.throws(function() {
+        const breaks = statsbreaks.breaks(X, { method, nb: 5, precision: 'abc' });
+      },
+      new InvalidPrecisionError("The 'precision' parameter must be a number"),
+      `should can be converted to a number (on method ${method})`,
+    );
+
+    // Test with a boolean
+    t.throws(function() {
+        const breaks = statsbreaks.breaks(X, { method, nb: 5, precision: true });
+      },
+      new InvalidPrecisionError("The 'precision' parameter must be a number"),
+      `should can be converted to a number (on method ${method})`,
+    );
+
+    // Test with an empty object
+    t.throws(function() {
+        const breaks = statsbreaks.breaks(X, { method, nb: 5, precision: {} });
+      },
+      new InvalidPrecisionError("The 'precision' parameter must be a number"),
+      `should can be converted to a number (on method ${method})`,
+    );
+
+    // Test with a string that can be converted to a positive integer
+    t.test(`on method ${method}, should succeed if the precision is a string that can be converted to a positive integer`,
+      function (t) {
+        const breaks = statsbreaks.breaks(X, { method, nb: 3, precision: '0' });
+        breaks.forEach(function(b) {
+          // Since we rounded to 0 digits, the breaks should be integers:
+          t.same(b % 1, 0);
+        });
+        t.end();
+      });
+
+    // Test with precision null
+    t.test(`on method ${method}, should not round breaks if precision is null`, function (t) {
+      const values = [
+        3.6643508679064443e-28, 7.294082182097556e-28, 1.4340929848339206e-27,
+        2.7857084049854467e-27, 5.344775300045348e-27, 1.0131982325610924e-26,
+        1.8973352773169297e-26, 3.5097084193183684e-26, 6.412821012971875e-26,
+        1.1576549807855486e-25, 2.0643593792949354e-25, 3.636102486891999e-25,
+        6.327622432834292e-25, 1.0877409751170753e-24, 1.8470852690626588e-24,
+        3.0980894887699536e-24, 5.1335525726319006e-24, 8.403479632386147e-24,
+        1.3587755172362854e-23, 2.170575708720219e-23, 3.4252501432321e-23,
+        5.339333723962586e-23, 8.221402331307723e-23, 1.2506330685399973e-22,
+        1.8793260537020868e-22, 2.7895234849124425e-22, 4.0906269906442664e-22,
+        5.925794882791488e-22, 8.479794793663697e-22, 1.198671444423588e-21,
+        1.6739052855873421e-21, 2.3092473458167115e-21, 3.1468426388799863e-21,
+        4.2365226372575385e-21, 5.6343540709988026e-21, 7.40244334070488e-21,
+        9.60714382165509e-21, 1.231778076166155e-20, 1.5602172469637237e-20,
+        1.9521987522069968e-20, 2.4131866691415125e-20, 2.946923020686793e-20,
+        3.555179944370005e-20, 4.237000689490457e-20, 4.9885928268100504e-20,
+        5.802622883210619e-20, 6.66774911389481e-20, 7.569544002639535e-20,
+        8.489563360489422e-20, 9.406542183353323e-20, 1.029681535089398e-19,
+        1.1135590709189528e-19, 1.189769547198936e-19
+      ];
+      const breaks = statsbreaks.breaks(values, { method, nb: 5, precision: null });
+      // We dont test that on the pretty method because it retuns breaks
+      // for which the min and the max are not the min and the max of the values
+      if (method !== 'pretty') {
+        const expectedBreaksMin = 3.6643508679064443e-28;
+        const expectedBreaksMax = 1.189769547198936e-19;
+        t.same(breaks[0], expectedBreaksMin);
+        t.same(breaks[breaks.length - 1], expectedBreaksMax);
+      }
+      t.end();
+    });
+
+    // Test with nb undefined
+    t.test(`on method ${method}, should round to 2 if precision is left undefined`, function (t) {
+      const values = [
+        3.6643508679064443e-28, 7.294082182097556e-28, 1.4340929848339206e-27,
+        2.7857084049854467e-27, 5.344775300045348e-27, 1.0131982325610924e-26,
+        1.8973352773169297e-26, 3.5097084193183684e-26, 6.412821012971875e-26,
+        1.1576549807855486e-25, 2.0643593792949354e-25, 3.636102486891999e-25,
+        6.327622432834292e-25, 1.0877409751170753e-24, 1.8470852690626588e-24,
+        3.0980894887699536e-24, 5.1335525726319006e-24, 8.403479632386147e-24,
+        1.3587755172362854e-23, 2.170575708720219e-23, 3.4252501432321e-23,
+        5.339333723962586e-23, 8.221402331307723e-23, 1.2506330685399973e-22,
+        1.8793260537020868e-22, 2.7895234849124425e-22, 4.0906269906442664e-22,
+        5.925794882791488e-22, 8.479794793663697e-22, 1.198671444423588e-21,
+        1.6739052855873421e-21, 2.3092473458167115e-21, 3.1468426388799863e-21,
+        4.2365226372575385e-21, 5.6343540709988026e-21, 7.40244334070488e-21,
+        9.60714382165509e-21, 1.231778076166155e-20, 1.5602172469637237e-20,
+        1.9521987522069968e-20, 2.4131866691415125e-20, 2.946923020686793e-20,
+        3.555179944370005e-20, 4.237000689490457e-20, 4.9885928268100504e-20,
+        5.802622883210619e-20, 6.66774911389481e-20, 7.569544002639535e-20,
+        8.489563360489422e-20, 9.406542183353323e-20, 1.029681535089398e-19,
+        1.1135590709189528e-19, 1.189769547198936e-19
+      ];
+      const breaks = statsbreaks.breaks(values, { method, nb: 5, minmax: false }); // Dont take minmax as it will help for comparison
+      breaks.forEach((b, i) => {
+        t.same(b, 0);
+      });
+      t.end();
+    });
+
+    t.end();
+  });
+
+});


### PR DESCRIPTION
This partially addresses issue #28 
- it don't round break values if `precision` is set to `null`
- it throw an error if `precision` is not an integer superior or equal to 0 (or cant be converted to such a number)
- it still defaults to 2 if `precision` is left undefined.

Maybe we can leave #28 open until we find a clever way to compute a default precision for when `precision` is left undefined, as you prefer.