### PR TITLE
Fix missing 'k' option when using MsdClassifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix missing `k` options when using the `classify` method of `MsdClassifier` (parameter `k` was ignored / not transferred to the underlying `msd` function).
+
 ## 1.0.3 (2023-07-20)
 
 - Don't round values if `precision` option is explicitly set to `null` (partially fixes [#28](https://github.com/riatelab/statsbreaks/issues/28)).

--- a/src/classifier.js
+++ b/src/classifier.js
@@ -459,6 +459,7 @@ class MsdClassifier extends AbstractClassifier {
     this.breaks = msd(this._values, {
       precision: this.precision,
       middle: middle,
+      k: k,
     });
     return this._breaks;
   }


### PR DESCRIPTION
Fix missing `k` options when using the `classify` method of `MsdClassifier` (parameter `k` was ignored / not transferred to the underlying `msd` function).