### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.5 (2023-10-02)
 
 - Add 'nested means' method (and `NestedMeansClassifier` class).
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,19 @@ The **`pretty`**  method generates breaks that are equally spaced round values w
 breaks(data, {method: "pretty", nb: 5, precision: 2 })
 ~~~
 
+#### `nested`
+
+The **`nested`**  method computes breaks using nested means : a first (arithmetic) mean divides the series in two, then each group is again split by its mean, and so on, until the desired number of classes is obtained. As such, the number of classes requested must be a power of 2 (2, 4, 8, etc.).
+
+~~~js
+breaks(data, {method: "nested", nb: 8, precision: 2 })
+~~~
+
 ## 3. Object-oriented API
 
 For each classification method, you can also use an object-oriented API.
 
-Classes available are: `JenksClassifier`, `EqualClassifier`, `GeometricProgressionClassifier`, `HeadTailClassifier`, `MsdClassifier`, `PrettyBreaksClassifier`, `QuantileClassifier`, `Q6Classifier`, `ArithmeticProgressionClassifier` and `CustomBreaksClassifier`.
+Classes available are: `JenksClassifier`, `EqualClassifier`, `GeometricProgressionClassifier`, `HeadTailClassifier`, `MsdClassifier`, `PrettyBreaksClassifier`, `QuantileClassifier`, `Q6Classifier`, `ArithmeticProgressionClassifier`, `NestedMeansClassifier` and `CustomBreaksClassifier`.
   
 For example
 


### PR DESCRIPTION
I updated the changelog to keep it sync with your last release but to my understanding and since you seem to follow semantic versionning, it should have been released as 1.1.0 (instead of 1.0.5) because it adds a new functionality in a backward compatible manner (cf. https://semver.org/).

It also updates the README about the new classification method.